### PR TITLE
Fix rollup warning

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -56,11 +56,14 @@ const mode = process.env.NODE_ENV;
 const dev = mode === 'development';
 const legacy = !!process.env.SAPPER_LEGACY_BUILD;
 
-const onwarn = (warning, onwarn) =>
-	(warning.code === 'MISSING_EXPORT' && /'preload'/.test(warning.message)) ||
-	(warning.code === 'CIRCULAR_DEPENDENCY' &&
-		/[/\\]@sapper[/\\]/.test(warning.message)) ||
-	onwarn(warning);
+const onwarn = (warning, onwarn) => {
+	return (
+		(warning.code === 'MISSING_EXPORT' && warning.binding === 'preload') ||
+		(warning.code === 'CIRCULAR_DEPENDENCY' &&
+			/[/\\]@sapper[/\\]/.test(warning.message)) ||
+		onwarn(warning)
+	);
+};
 
 const moduleExtensions = ['.mjs', '.js', '.json', '.node'];
 


### PR DESCRIPTION
https://github.com/sveltejs/sapper/issues/1380#issuecomment-732177707 is incomplete since the message contained `"preload"` for me not `'preload'` (double quotes vs single quote). Turns out I can use the binding instead which should be more robust.