### PR TITLE
chore: Remove obsolete action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: hmarr/debug-action@master
-
       - uses: actions/checkout@v4
         with:
           persist-credentials: true


### PR DESCRIPTION
GH workflows now have a convenient "rerun with debug"