### PR TITLE
chore: Migrate from deprecated set-output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Read .nvmrc
         id: nvm
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
 
       - name: Setup node
         uses: actions/setup-node@v3


### PR DESCRIPTION
Following https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/