### PR TITLE
Allow runing update workflow on-demand

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -6,6 +6,7 @@ on:
     # Monthly updates
     # https://crontab.guru/#0_0_1_*_*
     - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 jobs:
   static:


### PR DESCRIPTION
When I don't want to wait on schedule or push from `main`